### PR TITLE
Add missing version number for HA 2021.6 compatibility

### DIFF
--- a/custom_components/dewpoint/manifest.json
+++ b/custom_components/dewpoint/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/miguelangel-nubla/home-assistant-dewpoint",
   "dependencies": [],
   "codeowners": ["@miguelangel-nubla"],
-  "requirements": ["psychrolib==2.1.0"]
+  "requirements": ["psychrolib==2.1.0"],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Dewpoint didn't work with recent HA. Adding version key to manifest.json fixed that. As documented in https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions 
> The version key is required from Home Assistant version 2021.6