### PR TITLE
Update deprecated temperature units

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 [![License][license-shield]](LICENSE)
-![Project Maintenance][maintenance-shield]
-[![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
-# home-assistant-dewpoint
-Home Assistant custom component to calculate dew point using temperature and humidity sensors.
-Calculated using [psychrolib](https://github.com/psychrometrics/psychrolib).
+# Dew Point Calculator for Home Assistant
+[Home Assistant](https://www.home-assistant.io/) custom component to calculate dew point using temperature and humidity sensors based on [PsychroLib](https://github.com/psychrometrics/psychrolib).
 
+This repository was [forked](https://github.com/miguelangel-nubla/home-assistant-dewpoint) due to inactivity of the original creator and maintaner.
 
 ## Installation
-
-Use [hacs](https://custom-components.github.io/hacs/) with this repo URL https://github.com/miguelangel-nubla/home-assistant-dewpoint or copy `custom_components/` to your HA configuration.
+Use [HACS](https://hacs.xyz/) with this custom repository or copy `custom_components/` to your HA configuration.
 
 ## Example configuration.yaml
-
 ```yaml
 sensor:
   - platform: dewpoint
@@ -27,24 +23,18 @@ sensor:
 ```
 
 ## Configuration options
-
 Key | Type | Required | Description
 -- | -- | -- | --
-`sensors` | `list` | `True` | List of dewpoint sensors to generate.
+`sensors` | `list` | `True` | List of dew point sensors to generate
 
 ### Configuration options for `sensors` list
 
 Key | Type | Required | Default | Description
 -- | -- | -- | -- | --
-`friendly_name` | `string` | `False` | `sensor name` | Custom name for the new sensor entity.
-`temperature` | `entity_id` | `True` | `none` | Entity ID to read temperature from. (dry-bulb)
-`rel_hum` | `entity_id` | `True` | `none` | Entity ID to read relative humidity from.
-
+`friendly_name` | `string` | `False` | `sensor name` | Friendly name for the new sensor entity
+`temperature` | `entity_id` | `True` | `none` | Entity from which to get the dry-bulb temperature
+`rel_hum` | `entity_id` | `True` | `none` | Entity from which to get the relative humidity
 
 ***
 
-[dewpoint]: https://github.com/custom-components/dewpoint
-[buymecoffee]: https://www.buymeacoffee.com/miguelangelnubl
-[buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[license-shield]: https://img.shields.io/github/license/miguelangel-nubla/home-assistant-dewpoint.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-Miguel%20Angel%20Nubla%20Ruiz-blue.svg?style=for-the-badge
+[license-shield]: https://img.shields.io/github/license/ehn/home-assistant-dewpoint.svg?style=for-the-badge

--- a/custom_components/dewpoint/manifest.json
+++ b/custom_components/dewpoint/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/miguelangel-nubla/home-assistant-dewpoint",
   "dependencies": [],
   "codeowners": ["@miguelangel-nubla"],
-  "requirements": ["psychrolib==2.1.0"]
+  "requirements": ["psychrolib==2.1.0"],
+  "version": "0.0.0"
 }

--- a/custom_components/dewpoint/manifest.json
+++ b/custom_components/dewpoint/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "dewpoint",
-  "name": "DewPoint Sensor Calculator",
-  "documentation": "https://github.com/miguelangel-nubla/home-assistant-dewpoint",
-  "dependencies": [],
-  "codeowners": ["@miguelangel-nubla"],
+  "name": "Dew Point Calculator",
+  "documentation": "https://github.com/ehn/home-assistant-dewpoint",
+  "issue_tracker": "https://github.com/ehn/home-assistant-dewpoint/issues",
+  "codeowners": ["@miguelangel-nubla", "@lultimouomo", "@ehn"],
   "requirements": ["psychrolib==2.1.0"],
-  "version": "0.0.0"
+  "version": "0.0.1"
 }

--- a/custom_components/dewpoint/sensor.py
+++ b/custom_components/dewpoint/sensor.py
@@ -58,6 +58,7 @@ class DewPointSensor(Entity):
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, device_id, hass=hass
         )
+        self._unique_id = device_id
         self._name = name
 
         self._entity_dry_temp = entity_dry_temp
@@ -80,6 +81,11 @@ class DewPointSensor(Entity):
 
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_START, sensor_startup)
+
+    @property
+    def unique_id(self):
+        """Return the unique_id of the sensor."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/custom_components/dewpoint/sensor.py
+++ b/custom_components/dewpoint/sensor.py
@@ -2,7 +2,7 @@
 Calculate Dew Point based on temperature and humidity sensors
 
 For more details about this platform, please refer to the documentation
-https://github.com/miguelangel-nubla/home-assistant-dewpoint
+https://github.com/ehn/home-assistant-dewpoint
 """
 
 import logging

--- a/custom_components/dewpoint/sensor.py
+++ b/custom_components/dewpoint/sensor.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.core import callback
 from homeassistant.const import (
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_SENSORS,
+    UnitOfTemperature, ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_SENSORS,
     EVENT_HOMEASSISTANT_START, ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE)
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
@@ -105,7 +105,7 @@ class DewPointSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @callback
     def get_dry_temp(self, entity):
@@ -124,13 +124,13 @@ class DewPointSensor(Entity):
             return None
 
         # convert to celsius if necessary
-        if unit == TEMP_FAHRENHEIT:
+        if unit == UnitOfTemperature.FAHRENHEIT:
             return util.temperature.fahrenheit_to_celsius(temp)
-        if unit == TEMP_CELSIUS:
+        if unit == UnitOfTemperature.CELSIUS:
             return temp
         _LOGGER.error("Temp sensor %s has unsupported unit: %s (allowed: %s, "
-                      "%s)", state.entity_id, unit, TEMP_CELSIUS,
-                      TEMP_FAHRENHEIT)
+                      "%s)", state.entity_id, unit, UnitOfTemperature.CELSIUS,
+                      UnitOfTemperature.FAHRENHEIT)
 
         try:
             return self.hass.config.units.temperature(


### PR DESCRIPTION
Changed from TEMP_CELSIUS and TEMP_FAHRENHEIT constants (removed in HA 2025.1) to UnitOfTemperature enumerator.
See https://developers.home-assistant.io/blog/2022/10/26/new-unit-enumerators/
Closes [#14 ]